### PR TITLE
Add PDF to Excel converter with column reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # PDF-Import
+
+Ein kleines Tool, das Tabellen aus einer PDF-Datei extrahiert, als Excel-Datei speichert und ausgewählte Spalten nach vorne sortiert.
+
+## Nutzung
+
+```bash
+python pdf2excel.py input.pdf output.xlsx --move-first Kohlenstoffgehalt
+```
+
+## Abhängigkeiten
+
+```
+pip install pdfplumber pandas openpyxl
+```
+
+## Ohne Installation
+
+Mit [PyInstaller](https://pyinstaller.org/) kann ein einzelnes Binary erzeugt werden:
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile pdf2excel.py
+```
+
+Das entstehende Binary befindet sich im Verzeichnis `dist/` und kann ohne zusätzliche Installation ausgeführt werden.
+

--- a/pdf2excel.py
+++ b/pdf2excel.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""pdf2excel.py – extrahiert Tabellen aus einem PDF, exportiert sie nach Excel
+und sortiert ausgewählte Spalten nach vorne.
+
+Abhängigkeiten: pdfplumber, pandas, openpyxl
+Für ein einzelnes Binary kann anschließend pyinstaller verwendet werden.
+"""
+
+import argparse
+from typing import List
+
+import pdfplumber
+import pandas as pd
+
+
+def extract_tables(pdf_path: str) -> List[pd.DataFrame]:
+    """Liest alle Tabellen aus einem PDF und gibt sie als DataFrames zurück."""
+    frames: List[pd.DataFrame] = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            for raw_table in page.extract_tables():
+                df = pd.DataFrame(raw_table[1:], columns=raw_table[0])
+                frames.append(df)
+    return frames
+
+
+def export_excel(frames: List[pd.DataFrame], out_path: str, priority_cols: List[str]) -> None:
+    """Speichert Tabellen in eine Excel-Datei und sortiert priority_cols nach vorne."""
+    with pd.ExcelWriter(out_path) as writer:
+        for idx, df in enumerate(frames, start=1):
+            columns = priority_cols + [c for c in df.columns if c not in priority_cols]
+            df[columns].to_excel(writer, sheet_name=f"Tabelle{idx}", index=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PDF → Excel mit Spalten-Umsortierung")
+    parser.add_argument("pdf", help="Pfad zur PDF-Datei")
+    parser.add_argument("xlsx", help="Zielpfad der Excel-Datei")
+    parser.add_argument(
+        "--move-first",
+        nargs="+",
+        default=[],
+        help="Spaltennamen, die nach vorne sortiert werden sollen",
+    )
+    args = parser.parse_args()
+
+    tables = extract_tables(args.pdf)
+    export_excel(tables, args.xlsx, args.move_first)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `pdf2excel.py` script to extract PDF tables and reorder columns in resulting Excel sheets
- document usage and how to build a standalone binary with PyInstaller

## Testing
- `python pdf2excel.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689dc0847c788327b1b3aee09087c809